### PR TITLE
make schedule section a section

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: varnish
 Title: Front-end for The Carpentries Lesson Template
-Version: 0.0.0.9002
+Version: 0.0.0.9003
 Authors@R: 
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/inst/pkgdown/templates/content-syllabus.html
+++ b/inst/pkgdown/templates/content-syllabus.html
@@ -1,7 +1,7 @@
 <!-- START: inst/pkgdown/templates/content-syllabus.html -->
 
 <div class="row">
-  <div class="contents col-md-12">
+  <div class="section level1 contents col-md-12">
     <div class="page-header">
       <h1>{{pagetitle}}</h1>
     </div>

--- a/inst/pkgdown/templates/content-syllabus.html
+++ b/inst/pkgdown/templates/content-syllabus.html
@@ -13,9 +13,8 @@
 
 <div class="row">
   <div class="contents col-md-12">
-    <div class="page-header" id="schedule">
+    <div class="section level2" id="schedule">
       <h2>Schedule</h2>
-    </div>
     <table class="table table-striped table-responsive">
        <tr>
          <td class="col-md-2"></td>
@@ -28,11 +27,11 @@
        </tr>
   {{{syllabus}}}
     </table>
-
     <p>
       The actual schedule may vary slightly depending on the topics and exercises chosen by the instructor.
     </p>
 
+    </div>
   </div>
 </div>
 <!-- END  : inst/pkgdown/templates/content-syllabus.html -->

--- a/inst/pkgdown/templates/content-syllabus.html
+++ b/inst/pkgdown/templates/content-syllabus.html
@@ -1,13 +1,11 @@
 <!-- START: inst/pkgdown/templates/content-syllabus.html -->
 
 <div class="row">
-  <div class="section level1 contents col-md-12">
-    <div class="page-header">
+  <div class="contents col-md-12">
+    <div class="section level1 page-header">
       <h1>{{pagetitle}}</h1>
-    </div>
-
 {{{readme}}}
-
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
I should not try to write HTML when I'm tired, it turns out. Because schedule was templated as a page-header, the CSS demanded that it have a more prominent z-axis than the rest of the content and was covering it up. Thanks to @fmichonneau for pointing out the cause: https://github.com/zkamvar/sandpaper-docs/issues/1
