### PR TITLE
Modify index template for setup navigation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: varnish
 Title: Front-end for The Carpentries Lesson Template
-Version: 0.1.4
+Version: 0.1.5
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# varnish 0.1.5
+
+* The index page now has specific sections for schedule and setup that link to
+  the `#schedule` and `#setup` anchors. This partially addresses 
+  https://github.com/carpentries/sandpaper/issues/260
+
 # varnish 0.1.4
 
 * Removed " logo" suffix from the logo elements, as it is redundant

--- a/inst/pkgdown/templates/content-syllabus.html
+++ b/inst/pkgdown/templates/content-syllabus.html
@@ -19,19 +19,25 @@
       <h1 class="schedule-heading">{{{pagetitle}}}</h1>
       {{{readme}}}
       {{#syllabus}}
+      <section id="schedule">
       <table class="table schedule table-striped" role="presentation">
         <tbody>
+          {{#setup}}
           <tr>
-            <td></td><td><a href="setup.html">Setup Instructions</a></td><td> Download files required for the lesson</td>
+            <td></td><td><a href="#setup">Setup Instructions</a></td><td> Download files required for the lesson</td>
           </tr>
+          {{/setup}}
           {{{syllabus}}}
       </table>
       <p>
       The actual schedule may vary slightly depending on the topics and exercises chosen by the instructor.
       </p>
+      </section>
       {{/syllabus}}
       {{#setup}}
+      <section id="setup">
       {{{setup}}}
+      </section>
       {{/setup}}
     </main>
     <nav class="bottom-pagination mx-md-4" aria-label="Next Chapter">


### PR DESCRIPTION
This will update to address https://github.com/carpentries/sandpaper/issues/260 by creating sections for the setup and syllabus sections for the index page.

This will pair with https://github.com/carpentries/sandpaper/pull/262
