### PR TITLE
Add alternative workbench links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: varnish
 Title: Front-end for The Carpentries Lesson Template
-Version: 0.1.7
+Version: 0.1.8
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# varnish 0.1.8
+
+* custom workbench engines are now properly linked in the footer
+
 # varnish 0.1.7
 
 * compile the changes from 0.1.6

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # varnish 0.1.8
 
-* custom workbench engines are now properly linked in the footer
+* custom workbench engines are now properly linked in the footer via the 
+  `sandpaper_cfg` and `varnish_cfg` variables.
 
 # varnish 0.1.7
 

--- a/inst/pkgdown/templates/footer.html
+++ b/inst/pkgdown/templates/footer.html
@@ -10,9 +10,9 @@
         <p>Materials licensed under <a href="{{#site}}{{root}}{{/site}}LICENSE.html">{{license}}</a> by the authors</p>
         {{/license}}{{/yaml}}
         <p><a href="https://creativecommons.org/licenses/by-sa/4.0/">Template licensed under CC-BY 4.0</a> by <a href="https://carpentries.org">The Carpentries</a></p>
-        <p>Built with <a href="https://github.com/carpentries/sandpaper">sandpaper{{sandpaper_version}}</a>,
+        <p>Built with <a href="https://github.com/{{sandpaper_cfg}}{{^sandpaper_cfg}}carpentries/sandpaper{{/sandpaper_cfg}}">sandpaper{{sandpaper_version}}</a>,
       <a href="https://github.com/carpentries/pegboard">pegboard{{pegboard_version}}</a>,
-      and <a href="https://github.com/carpentries/varnish">varnish{{varnish_version}}</a>.</p>
+      and <a href="https://github.com/{{varnish_cfg}}{{^varnish_cfg}}carpentries/varnish{{/varnish_cfg}}">varnish{{varnish_version}}</a>.</p>
 			</div>
 		</footer>
 	</div> <!-- / div.container -->


### PR DESCRIPTION
From https://github.com/carpentries/actions/releases/tag/v0.8, it is possible for lesson authors to specify their own versions of sandpaper and varnish to build thier lessons. This PR adds the `sandpaper_cfg` and `varnish_cfg` variables to the footer links so that the correct links can be added in (once sandpaper accounts for these).
