### PR TITLE
update code of conduct link

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 * custom workbench engines are now properly linked in the footer via the 
   `sandpaper_cfg` and `varnish_cfg` variables.
+* code of conduct link now points to the `CODE_OF_CONDUCT.md` file so authors
+  can update or modify their own code of conduct (NOTE: all Carpentries lessons
+  MUST have a code of conduct that links to the Carpentries Code of Conduct as
+  well as the reporting guidelines.
 
 # varnish 0.1.7
 

--- a/inst/pkgdown/templates/footer.html
+++ b/inst/pkgdown/templates/footer.html
@@ -1,7 +1,7 @@
 		<footer class="row footer mx-md-3">
 			<hr/>
 			<div class="col-md-6">
-				<p>All Carpentry lessons are subject to the <a href="https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html">Code of Conduct</a></p>
+				<p>This lesson is subject to the <a href="CODE_OF_CONDUCT.html">Code of Conduct</a></p>
 				<p><a href="{{#yaml}}{{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on Github</a> | <a href="{{#yaml}}{{source}}/blob/{{branch}}/{{/yaml}}CONTRIBUTING.md">Contributing</a> | <a href="{{#yaml}}{{source}}/{{/yaml}}">Source</a></p>
 				<p><a href="{{#yaml}}{{source}}/blob/{{branch}}/{{/yaml}}CITATION">Cite</a> | <a href="mailto:{{#yaml}}{{contact}}{{/yaml}}">Contact</a> | <a href="https://carpentries.org/about/">About</a></p>
 			</div>


### PR DESCRIPTION
This updates the CoC link to point to `CODE_OF_CONDUCT.md`, which allows folks to include their own codes of conduct.
