### PR TITLE
hard-code generated resources in mobile nav

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: varnish
 Title: Front-end for The Carpentries Lesson Template
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# varnish 0.2.1
+
+* The sidebar navigation in mobile and tablet views now includes all the 
+  information that was included in the navigation bar for the desktop mode. 
+  (reported: https://github.com/carpentries/workbench/issues/16#issuecomment-1165307355 by @Athanasiamo and #49, fixed: #50 by @zkamvar)
+
 # varnish 0.2.0
 
 * The sidebar state (expanded or collapsed) will now persist during navigation

--- a/inst/pkgdown/templates/navbar.html
+++ b/inst/pkgdown/templates/navbar.html
@@ -121,6 +121,8 @@
             </div>
             {{/resources}}
 
+            <hr class="half-width"/>
+
             {{#aio}}<a href="{{#site}}{{root}}{{/site}}{{#instructor}}instructor/{{/instructor}}aio.html">See all in one page</a>{{/aio}}
 
             <hr class="d-none d-sm-block d-md-none"/>

--- a/inst/pkgdown/templates/navbar.html
+++ b/inst/pkgdown/templates/navbar.html
@@ -119,7 +119,7 @@
                 </div>
               </div>
             </div>
-            <hr class="half-width"/>
+            <hr class="half-width resources"/>
             {{/resources}}
 
             {{#aio}}<a href="{{#site}}{{root}}{{/site}}{{#instructor}}instructor/{{/instructor}}aio.html">See all in one page</a>{{/aio}}

--- a/inst/pkgdown/templates/navbar.html
+++ b/inst/pkgdown/templates/navbar.html
@@ -119,9 +119,8 @@
                 </div>
               </div>
             </div>
-            {{/resources}}
-
             <hr class="half-width"/>
+            {{/resources}}
 
             {{#aio}}<a href="{{#site}}{{root}}{{/site}}{{#instructor}}instructor/{{/instructor}}aio.html">See all in one page</a>{{/aio}}
 

--- a/inst/pkgdown/templates/navbar.html
+++ b/inst/pkgdown/templates/navbar.html
@@ -91,6 +91,28 @@
                 <div id="flush-collapseTwelve" class="accordion-collapse collapse" aria-labelledby="flush-headingTwelve" data-bs-parent="#accordionFlush12">
                   <div class="accordion-body">
                     <ul>
+                      {{#instructor}}
+                      <li>
+                        <a href="{{#site}}{{root}}{{/site}}instructor/key-points.html">Key Points</a>
+                      </li>
+                      <li>
+                        <a href="{{#site}}{{root}}{{/site}}instructor/instructor-notes.html">Instructor Notes</a>
+                      </li>
+                      <li>
+                        <a href="{{#site}}{{root}}{{/site}}instructor/images.html">Extract All Images</a>
+                      </li>
+                      {{/instructor}}
+                      {{^instructor}}
+                      <li>
+                        <a href="{{#site}}{{root}}{{/site}}key-points.html">Key Points</a>
+                      </li>
+                      <li>
+                        <a href="{{#site}}{{root}}{{/site}}reference.html#glossary">Glossary</a>
+                      </li>
+                      <li>
+                        <a href="{{#site}}{{root}}{{/site}}profiles.html">Learner Profiles</a>
+                      </li>
+                      {{/instructor}}
                       {{{resources}}}
                     </ul>
                   </div>


### PR DESCRIPTION
This adds the correct resources in the dropdown by default so that users on mobile will have the same access.

This will fix https://github.com/carpentries/varnish/issues/49
See https://github.com/carpentries/sandpaper/issues/306 for details of issue

