### PR TITLE
update workbench beta message:

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: varnish
 Title: Front-end for The Carpentries Lesson Template
-Version: 0.2.4
+Version: 0.2.5
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# varnish 0.2.5
+
+* Workbench Beta messaging has been modified to be more visible and to link back
+  to the original lesson if possible.
+- The icon for lessons in "alpha" has been updated so it has a yellow background
+  with a grey glyph so that the icon shows up better.
+
 # varnish 0.2.4
 
 * Callout block titles have been improved: The underline height for titles have

--- a/inst/pkgdown/templates/footer.html
+++ b/inst/pkgdown/templates/footer.html
@@ -35,7 +35,7 @@
           var _paq = window._paq = window._paq || [];
           /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
           _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-          _paq.push(["setDomains", ["*.lessons.carpentries.org","*.datacarpentry.github.io","*.datacarpentry.org","*.librarycarpentry.github.io","*.librarycarpentry.org","*.swcarpentry.github.io", "*.carpentries.github.io"]]);
+          _paq.push(["setDomains", ["*.preview.carpentries.org","*.datacarpentry.github.io","*.datacarpentry.org","*.librarycarpentry.github.io","*.librarycarpentry.org","*.swcarpentry.github.io", "*.carpentries.github.io"]]);
           _paq.push(["setDoNotTrack", true]);
           _paq.push(["disableCookies"]);
           _paq.push(['trackPageView']);

--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -38,10 +38,30 @@
     <div class="selector-container ">
       {{#yaml}}{{#workbench-beta}}
       <div class="beta-alert alert alert-light alert-dismissable fade show" role="alert">
+        {{#pre-beta-date}}
+        <abbr class="icon" title="This lesson is in the Workbench Beta Phase (pre-beta stage) and is a snapshot of {{&title}} from {{pre-beta-date}}. Editing this page will have no effect on the lesson. Click here to go back to the styles version." style="text-decoration: unset">
+          <span class="visually-hidden">This lesson is in the Workbench Beta Phase (pre-beta stage) and is a snapshot of {{&title}} from {{pre-beta-date}}. Editing this page will have no effect on the lesson.</span>
+          <a href="{{old-url}}" class="alert-link" style="color: #383838">
+            <i aria-hidden="true" class="icon" data-feather="alert-triangle" style="background: #FFC700; border-radius: 5px"></i>
+            <span class="visually-hidden">Visit the styles version of the lesson</span>
+          </a>
+        </abbr>
+        {{/pre-beta-date}}
+        {{#beta-date}}
+        <abbr class="icon" title="This lesson is in the Workbench Beta Phase (beta stage). Click here to visit a snapshot of the styles version from {{beta-date}}." style="text-decoration: unset">
+            <span class="visually-hidden">This lesson is in the Workbench Beta Phase (beta stage).</span>
+          <a href="{{old-url}}" class="alert-link" style="color: #383838">
+            <i aria-hidden="true" class="icon" data-feather="alert-circle" style="background: #719eff; border-radius: 5px"></i>
+            <span class="visually-hidden">Visit a snapshot of the styles version from {{beta-date}}</span>
+          </a>
+        </abbr>
+        {{/beta-date}}
+        {{^beta-date}}{{^pre-beta-date}}
         <i aria-hidden="true" class="icon" data-feather="alert-circle" style="color: #5bbad5"></i>
+        {{/pre-beta-date}}{{/beta-date}}
         Workbench Beta | 
-        <a href="https://github.com/carpentries/workbench/discussions" class="alert-link">Give Feedback</a> | 
-        <a href="https://carpentries.github.io/workbench" class="alert-link">Learn More</a>
+        <a href="https://github.com/carpentries/workbench/discussions" class="alert-link" style="text-decoration: wavy overline">Give Feedback</a> | 
+        <a href="https://carpentries.github.io/workbench/beta-phase.html" class="alert-link">Learn More</a>
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
       </div>
       {{/workbench-beta}}{{/yaml}}

--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -9,7 +9,7 @@
         <abbr class="icon" title="This lesson is in the pre-alpha phase, which means that it is in early development, but has not yet been taught." style="text-decoration: unset">
           &nbsp;
           <a href="https://cdh.carpentries.org/the-lesson-life-cycle.html#early-development-pre-alpha-through-alpha" class="alert-link" style="color: #383838">Pre-Alpha
-            <i aria-hidden="true" class="icon" data-feather="alert-octagon" style="color: #FF4955"></i>
+            <i aria-hidden="true" class="icon" data-feather="alert-octagon" style="color: #FF4955; border-radius: 5px"></i>
           </a>
           <span class="visually-hidden">This lesson is in the pre-alpha phase, which means that it is in early development, but has not yet been taught.</span>
         </abbr>
@@ -18,7 +18,7 @@
         <abbr class="icon" title="This lesson is in the alpha phase, which means that it has been taught once and lesson authors are iterating on feedback." style="text-decoration: unset">
           &nbsp;
           <a href="https://cdh.carpentries.org/the-lesson-life-cycle.html#field-testing-alpha-stage" class="alert-link" style="color: #383838">Alpha
-            <i aria-hidden="true" class="icon" data-feather="alert-triangle" style="color: #FFC700"></i>
+            <i aria-hidden="true" class="icon" data-feather="alert-triangle" style="background: #FFC700; border-radius: 5px"></i>
           </a>
           <span class="visually-hidden">This lesson is in the alpha phase, which means that it has been taught once and lesson authors are iterating on feedback.</span>
         </abbr>
@@ -27,7 +27,7 @@
         <abbr class="icon" title="This lesson is in the beta phase, which means that it is ready for teaching by instructors outside of the original author team." style="text-decoration: unset">
           &nbsp;
           <a href="https://cdh.carpentries.org/the-lesson-life-cycle.html#polishing-beta-stage" class="alert-link" style="color: #383838">Beta
-            <i aria-hidden="true" class="icon" data-feather="alert-circle" style="color: #001483"></i>
+            <i aria-hidden="true" class="icon" data-feather="alert-circle" style="color: #001483; border-radius: 5px"></i>
           </a>
           <span class="visually-hidden">This lesson is in the beta phase, which means that it is ready for teaching by instructors outside of the original author team.</span>
         </abbr>


### PR DESCRIPTION
This adds more information for lessons in the beta phase

 - more icons for different stages of the beta
 - wavy overline for feedback
 - learn more link goes to workbench beta page

This also gives lessons in alpha a more visible icon by setting yellow as the background
