### PR TITLE
add survey url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: varnish
 Title: Front-end for The Carpentries Lesson Template
-Version: 0.2.5
+Version: 0.2.6
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# varnish 0.2.6
+
+* For lessons that use `workbench-beta: true`, the feedback URL has changed from
+  <https://github.com/carpentries/workbench/discussions/> to 
+  <https://carpentries.typeform.com/to/KRBl4IZM>, so that we can get more
+  specific feedback.
+
 # varnish 0.2.5
 
 * Workbench Beta messaging has been modified to be more visible and to link back

--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -60,7 +60,7 @@
         <i aria-hidden="true" class="icon" data-feather="alert-circle" style="color: #5bbad5"></i>
         {{/pre-beta-date}}{{/beta-date}}
         Workbench Beta | 
-        <a href="https://github.com/carpentries/workbench/discussions" class="alert-link" style="text-decoration: wavy overline">Give Feedback</a> | 
+        <a href="https://carpentries.typeform.com/to/KRBl4IZM" class="alert-link" style="text-decoration: wavy overline">Give Feedback</a> | 
         <a href="https://carpentries.github.io/workbench/beta-phase.html" class="alert-link">Learn More</a>
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
       </div>


### PR DESCRIPTION
For lessons that use `workbench-beta: true`, the feedback URL has changed from <https://github.com/carpentries/workbench/discussions/> to <https://carpentries.typeform.com/to/KRBl4IZM>, so that we can get more specific feedback.
