### PR TITLE
modify beta urls

### DIFF
--- a/inst/pkgdown/templates/content-chapter.html
+++ b/inst/pkgdown/templates/content-chapter.html
@@ -24,7 +24,18 @@
     <main id="main-content" class="main-content">
       <div class="container lesson-content">
         <h1>{{& pagetitle}}</h1>
-        <p>{{#updated}} Last updated on {{updated}} | {{/updated}}<a href="{{#yaml}}{{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit this page <i aria-hidden="true" data-feather="edit"></i></a></p>
+        <p>{{#updated}} Last updated on {{updated}} | {{/updated}}
+        {{#yaml}}
+        {{^beta-date}}{{^pre-beta-date}}
+        <a href="{{#yaml}}{{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit this page <i aria-hidden="true" data-feather="edit"></i></a></p>
+        {{/pre-beta-date}}{{/beta-date}}
+        {{#pre-beta-date}}
+        <a href="{{#yaml}}https://carpentries.github.io/workbench/contributor/pre-beta.html?id={{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit this page <i aria-hidden="true" data-feather="edit"></i></a></p>
+        {{/pre-beta-date}}
+        {{#beta-date}}{{^pre-beta-date}}
+        <a href="{{#yaml}}https://carpentries.github.io/workbench/contributor/beta.html?id={{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit this page <i aria-hidden="true" data-feather="edit"></i></a></p>
+        {{/pre-beta-date}}{{/beta-date}}
+        {{/yaml}}
         {{#instructor}}
         {{#minutes}}<p>Estimated time <i aria-hidden="true" data-feather="clock"></i> {{minutes}} minutes </p>{{/minutes}}
         {{#slides}}<p><button class="btn btn-primary-outline">Export Chapter Slides</button></p>{{/slides}}

--- a/inst/pkgdown/templates/footer.html
+++ b/inst/pkgdown/templates/footer.html
@@ -2,7 +2,19 @@
 			<hr/>
 			<div class="col-md-6">
 				<p>This lesson is subject to the <a href="CODE_OF_CONDUCT.html">Code of Conduct</a></p>
-				<p><a href="{{#yaml}}{{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on Github</a> | <a href="{{#yaml}}{{source}}/blob/{{branch}}/{{/yaml}}CONTRIBUTING.md">Contributing</a> | <a href="{{#yaml}}{{source}}/{{/yaml}}">Source</a></p>
+				<p><a href="{{#yaml}}{{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on Github</a> 
+        {{#yaml}}
+        {{^beta-date}}{{^pre-beta-date}}
+        <a href="{{#yaml}}{{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on GitHub</a></p>
+        {{/pre-beta-date}}{{/beta-date}}
+        {{#pre-beta-date}}
+        <a href="{{#yaml}}https://carpentries.github.io/workbench/contributor/pre-beta.html?id={{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on GitHub</a></p>
+        {{/pre-beta-date}}
+        {{#beta-date}}{{^pre-beta-date}}
+        <a href="{{#yaml}}https://carpentries.github.io/workbench/contributor/beta.html?id={{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on GitHub</a></p>
+        {{/pre-beta-date}}{{/beta-date}}
+        {{/yaml}}
+        | <a href="{{#yaml}}{{source}}/blob/{{branch}}/{{/yaml}}CONTRIBUTING.md">Contributing</a> | <a href="{{#yaml}}{{source}}/{{/yaml}}">Source</a></p>
 				<p><a href="{{#yaml}}{{source}}/blob/{{branch}}/{{/yaml}}CITATION">Cite</a> | <a href="mailto:{{#yaml}}{{contact}}{{/yaml}}">Contact</a> | <a href="https://carpentries.org/about/">About</a></p>
 			</div>
 			<div class="col-md-6">


### PR DESCRIPTION
This will modify "Edit on GitHub"/"Edit this page" urls so that they point to

`https://carpentries.github.io/workbench/contributor/<phase>.html?<url-to-edit`

This will address the question posed in https://github.com/carpentries/workbench/discussions/30

Here is an example of what clicking on "Improve this page" will look like from
[the fourth episode of R for ecologists](https://preview.carpentries.org/R-ecology-lesson/03-dplyr.html).

https://carpentries.github.io/workbench/contributor/pre-beta.html?id=https://github.com/fishtree-attempt/R-ecology-lesson/edit/main/episodes/03-dplyr.Rmd
