### PR TITLE
fix footer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: varnish
 Title: Front-end for The Carpentries Lesson Template
-Version: 0.2.7
+Version: 0.2.8
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# varnish 0.2.8
+
+- Workbench Beta phase "Edit on GitHub" links are now formatted correctly.
+  (reported: @zkamvar, #65; fixed @zkamvar, #67)
+
 # varnish 0.2.7
 
 * Lessons in different phases of the workbench beta phase will now have the URLs

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # varnish 0.2.8
 
 - Workbench Beta phase "Edit on GitHub" links are now formatted correctly.
-  (reported: @zkamvar, #65; fixed @zkamvar, #67)
+  (reported: @zkamvar, #65; fixed @zkamvar, #66)
 
 # varnish 0.2.7
 

--- a/inst/pkgdown/templates/footer.html
+++ b/inst/pkgdown/templates/footer.html
@@ -2,19 +2,20 @@
 			<hr/>
 			<div class="col-md-6">
 				<p>This lesson is subject to the <a href="CODE_OF_CONDUCT.html">Code of Conduct</a></p>
-				<p><a href="{{#yaml}}{{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on Github</a> 
         {{#yaml}}
-        {{^beta-date}}{{^pre-beta-date}}
-        <a href="{{#yaml}}{{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on GitHub</a></p>
-        {{/pre-beta-date}}{{/beta-date}}
+        <p>
+        {{^old-url}}
+        <a href="{{#yaml}}{{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on GitHub</a>
+        {{/old-url}}
         {{#pre-beta-date}}
-        <a href="{{#yaml}}https://carpentries.github.io/workbench/contributor/pre-beta.html?id={{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on GitHub</a></p>
+        <a href="{{#yaml}}https://carpentries.github.io/workbench/contributor/pre-beta.html?id={{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on GitHub</a>
         {{/pre-beta-date}}
-        {{#beta-date}}{{^pre-beta-date}}
-        <a href="{{#yaml}}https://carpentries.github.io/workbench/contributor/beta.html?id={{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on GitHub</a></p>
-        {{/pre-beta-date}}{{/beta-date}}
+        {{#beta-date}}
+        <a href="{{#yaml}}https://carpentries.github.io/workbench/contributor/beta.html?id={{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on GitHub</a>
+        {{/beta-date}}
         {{/yaml}}
-        | <a href="{{#yaml}}{{source}}/blob/{{branch}}/{{/yaml}}CONTRIBUTING.md">Contributing</a> | <a href="{{#yaml}}{{source}}/{{/yaml}}">Source</a></p>
+        | <a href="{{#yaml}}{{source}}/blob/{{branch}}/{{/yaml}}CONTRIBUTING.md">Contributing</a> 
+        | <a href="{{#yaml}}{{source}}/{{/yaml}}">Source</a></p>
 				<p><a href="{{#yaml}}{{source}}/blob/{{branch}}/{{/yaml}}CITATION">Cite</a> | <a href="mailto:{{#yaml}}{{contact}}{{/yaml}}">Contact</a> | <a href="https://carpentries.org/about/">About</a></p>
 			</div>
 			<div class="col-md-6">


### PR DESCRIPTION
In my haste with version 0.2.7, I accidentally duplicated the edit on
github URLs, which caused the footer to be malformed. I had additionally
added an extra closing p tag where it was not needed.

This will fix #65
