### PR TITLE
fix beta url in footer

### DIFF
--- a/inst/pkgdown/templates/content-chapter.html
+++ b/inst/pkgdown/templates/content-chapter.html
@@ -33,7 +33,7 @@
         <a href="{{#yaml}}https://carpentries.github.io/workbench/contributor/pre-beta.html?id={{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit this page <i aria-hidden="true" data-feather="edit"></i></a></p>
         {{/pre-beta-date}}
         {{#beta-date}}{{^pre-beta-date}}
-        <a href="{{#yaml}}https://carpentries.github.io/workbench/contributor/beta.html?id={{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit this page <i aria-hidden="true" data-feather="edit"></i></a></p>
+        <a href="{{#yaml}}{{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit this page <i aria-hidden="true" data-feather="edit"></i></a></p>
         {{/pre-beta-date}}{{/beta-date}}
         {{/yaml}}
         {{#instructor}}

--- a/inst/pkgdown/templates/footer.html
+++ b/inst/pkgdown/templates/footer.html
@@ -7,12 +7,14 @@
         {{^old-url}}
         <a href="{{#yaml}}{{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on GitHub</a>
         {{/old-url}}
+	{{#old-url}}
         {{#pre-beta-date}}
         <a href="{{#yaml}}https://carpentries.github.io/workbench/contributor/pre-beta.html?id={{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on GitHub</a>
         {{/pre-beta-date}}
-        {{#beta-date}}
-        <a href="{{#yaml}}https://carpentries.github.io/workbench/contributor/beta.html?id={{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on GitHub</a>
-        {{/beta-date}}
+        {{^pre-beta-date}}
+        <a href="{{#yaml}}{{source}}/edit/{{branch}}/{{/yaml}}{{file_source}}{{^file_source}}README.md{{/file_source}}">Edit on GitHub</a>
+        {{/pre-beta-date}}
+	{{/old-url}}
         {{/yaml}}
         | <a href="{{#yaml}}{{source}}/blob/{{branch}}/{{/yaml}}CONTRIBUTING.md">Contributing</a> 
         | <a href="{{#yaml}}{{source}}/{{/yaml}}">Source</a></p>


### PR DESCRIPTION
the "edit on github" was moving people to the beta stage landing page, which was inaccurate for the preview version.
