### PR TITLE
Make space below schedule smaller

### DIFF
--- a/source/stylesheets/schedule.scss
+++ b/source/stylesheets/schedule.scss
@@ -4,7 +4,7 @@
 }
 
 .schedule {
-  margin-bottom: 225px;
+  margin-bottom: 25px;
 }
 
 .schedule td {


### PR DESCRIPTION
Set the `margin-bottom` to 25 px instead of 225 px. I don't have a specific reason for this number, but it is a lot smaller. Fixes #81.