### PR TITLE
allow inline text with dollarsigns to be not mathed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: varnish
 Title: Front-end for The Carpentries Lesson Template
-Version: 0.2.17
+Version: 0.2.18
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # varnish 0.2.18
 
 * Non-math elements on the same line will no longer be treated as math
-  (reported: @marklcrowe, #88; fixed: @zkamvar, #89)
+  (reported: @marklcrowe, #88; fixed: @zkamvar, #90)
 
 # varnish 0.2.17
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# varnish 0.2.18
+
+* Non-math elements on the same line will no longer be treated as math
+  (reported: @marklcrowe, #88; fixed: @zkamvar, #89)
+
 # varnish 0.2.17
 
 * The margin below the schedule table in instructor view is now 25px instead of

--- a/inst/pkgdown/templates/head.html
+++ b/inst/pkgdown/templates/head.html
@@ -13,7 +13,7 @@
         extensions: ["AMSmath.js","AMSsymbols.js","noErrors.js","noUndefined.js"]
       },
       tex2jax: {
-        inlineMath: [ ['$','$'], ['\\(', '\\)']],
+        inlineMath: [['\\(', '\\)']],
         displayMath: [ ['$$','$$'], ['\\[', '\\]'] ],
         processEscapes: true
       }


### PR DESCRIPTION
This removes the use of `$` delimiters for MathJax since pandoc will allow those.


You can confirm this works by doing the following:

1. clone `carpentries/sandpaper-docs`
2. add these lines to `index.md`:
   ```markdown
   I have \$2 USD and \$5 CAD
   
   This is math $1\frac{a}{b}$
   ```
3. install this version of varnish: `devtools::install("carpentries/varnish#90")`
4. preview the lesson with sandpaper


This will fix #88