### PR TITLE
add an image-with-shadow class

### DIFF
--- a/source/stylesheets/styles.css.scss
+++ b/source/stylesheets/styles.css.scss
@@ -190,6 +190,11 @@ figcaption {
   padding: 25px;
 }
 
+img.image-with-shadow {
+  box-shadow: 0 0.39em 1.56em 0 #888;
+  margin-bottom: 2em;
+}
+
 .section-heading {
   margin-top: 100px;
 }


### PR DESCRIPTION
Resolves https://github.com/carpentries/workbench/issues/46 by adding an `image-with-shadow` class that can be used to make the boundaries of images with white backgrounds stand out against the lesson page.