### PR TITLE
Bugfix: Avoid double html escaping of lesson title.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,11 @@ Authors@R: c(
            family = "Michonneau",
            role = c("ctb"),
            email = "francois@carpentries.org"),
+    person(given = "Robert",
+           family = "Chisholm",
+           role = c("ctb"),
+           email = "robert.chisholm@sheffield.ac.uk",
+           comment = c(ORCID = "0000-0003-3379-9042")),
     person()
     )
 Description: This package does nothing but contain template HTML CSS and JS files.

--- a/inst/pkgdown/templates/head.html
+++ b/inst/pkgdown/templates/head.html
@@ -1,5 +1,5 @@
     <meta charset="utf-8">
-    <title>{{#site}}{{title}}{{/site}}{{#pagetitle}}: {{&pagetitle}}{{/pagetitle}}</title>
+    <title>{{#site}}{{&title}}{{/site}}{{#pagetitle}}: {{&pagetitle}}{{/pagetitle}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="{{#site}}{{root}}{{/site}}assets/styles.css">
     <script src="{{#site}}{{root}}{{/site}}assets/scripts.js" type="text/javascript"></script>

--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -108,7 +108,7 @@
       <img class="small-logo" alt="{{#yaml}}{{carpentry_name}}{{/yaml}}" src="{{#site}}{{root}}{{/site}}assets/images/{{#yaml}}{{carpentry_icon}}-logo-sm.svg{{/yaml}}">
     </div>
     <div class="lesson-title-md">
-      {{#site}}{{title}}{{/site}}
+      {{#site}}{{&title}}{{/site}}
     </div>
     <div class="search-icon-sm">
       <!-- TODO: do not show until we have search
@@ -119,7 +119,7 @@
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
         <li class="nav-item">
           <span class="lesson-title">
-            {{#site}}{{title}}{{/site}}
+            {{#site}}{{&title}}{{/site}}
           </span>
         </li>
         {{#overview}}
@@ -181,7 +181,7 @@
 </nav>
 
 <div class="col-md-12 mobile-title">
-  {{#site}}{{title}}{{/site}}
+  {{#site}}{{&title}}{{/site}}
 </div>
 
 {{^overview}}


### PR DESCRIPTION
There is currently a bug whereby `title` (from `config.yaml`), if containing `&`, will be double encoded to converting them to `&amp;amp;` in 4 locations of the templates. This presumably applies to other HTML encoded characters too.

See: https://github.com/r-lib/pkgdown/pull/298, where they addressed the same issue, albeit with a different fix (which caused `NULL` to be rendered when I attempted with the carpentries template).

The same fix already appears present on this and the following lines: https://github.com/carpentries/varnish/blob/8b930523e56f4003b381353d6f945228664584a4/inst/pkgdown/templates/header.html#L42

I'm not particularly familiar with `pkgdown`, [`mustache`](https://mustache.github.io/mustache.5.html) (where I found this alt-fix) or R, so it's possible there's a better resolution or I've missed something. I did however check all files in `inst/pkgdown/templates` for `{{title}}`.

*I discovered this whilst developing a forked varnish with internal branding for a new course I'll likely be developing soon (we may submit to incubator when it's more than a plan). You can find that WIP [here](https://robadob.github.io/pando-express/) with the issue resolved.*

*I also noticed that [this](https://carpentries-incubator.github.io/jekyll-pages-novice/) lesson from the incubator [list](https://carpentries-incubator.github.io/jekyll-pages-novice/), had simply switch to `and` in order to presumably work around this issue.*