### PR TITLE
Bugfix: .card-title text would wrap at high screen widths.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,10 +16,12 @@
 
 * Overview box heading font sizes now scaled based on viewport size. This fixes
   issues where the heading would wrap in an ugly fashion.
-  (reported: @jd-foster, https://github.com/carpentries/varnish/issues/83, 
+  (reported: @jd-foster, #83, 
   @drmownickles, https://github.com/carpentries/workbench/issues/57,
-  @rbavery, https://github.com/carpentries/workbench/issues/64; fixed:
-  @froggleston, https://github.com/carpentries/varnish/pull/109).
+  @rbavery, https://github.com/carpentries/workbench/issues/64, 
+  @robadob, #111; fixed:
+  @froggleston, #109, 
+  @robadob, #112).
 * Spacing and alignment of text improved in Software Carpentry logo.
   (reported: @tobyhodges, #107; fixed @tobyhodges, #110).
 

--- a/source/stylesheets/overview.scss
+++ b/source/stylesheets/overview.scss
@@ -39,7 +39,7 @@
   text-decoration-thickness: 1px;
   text-underline-offset: 25px;
   margin-bottom: 50px;
-  font-size: calc(22px + 0.2vw);
+  font-size: min(25px, calc(22px + 0.2vw));
   font-weight: 600;
   line-height: 1.5rem;
 }


### PR DESCRIPTION
Making this change inside chrome's dev tools fixes it, at the cost of limiting the font size when the side bar is collapsed (with the sidebar collapsed, on a 1440p monitor the font size would previously peak at 27.12px and not wrap)

It caps the font size to 25px, as the issue occurs at ~25.29px.

Before (27.12px)
![image](https://github.com/carpentries/varnish/assets/742154/3a8d06f3-4ee1-4f76-90d6-dfe486e13ad4)

After (25px)
![image](https://github.com/carpentries/varnish/assets/742154/a8fade9f-ed8c-4248-8bca-561302435600)

Might be possible to instead dynamically apply the cap when the sidebar is expanded. But I'm far from a front-end web developer.

I'm not sure I understand why the font even scales with screen width, above 1350px screen width (with sidebar collapsed) or 1229px (with sidebar expanded), the box it's contained within has a static size. Furthermore, when screen width drops below 1200px, the sidebar is hidden so the box expands to follow screen width but the font size continues reducing.


Closes #111
