### PR TITLE
Bugfix: Lesson title would collide with search box at certain widths.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
   @froggleston, https://github.com/carpentries/varnish/pull/109).
 * Spacing and alignment of text improved in Software Carpentry logo.
   (reported: @tobyhodges, #107; fixed @tobyhodges, #110).
+* Lesson title collision with search box resolved.
+  (reported: @ocasia, #84; fixed @robadob, #113).
 
 # varnish 0.4.0 (2023-11-29)
 

--- a/source/stylesheets/header.scss
+++ b/source/stylesheets/header.scss
@@ -358,6 +358,7 @@
     left: 10%;
     margin-bottom: 30px;
     margin-top: 25px;
+    margin-right: 200px;
   }
 
   .top-nav {


### PR DESCRIPTION
Before
![image](https://github.com/carpentries/varnish/assets/742154/f3996d4b-f049-420c-bb23-8d667c66342f)


After
![image](https://github.com/carpentries/varnish/assets/742154/54bf37cd-d8f1-4098-abee-a19e3ba5cfff)

The rule sits within a media breakpoint so is only active between window widths 768-1200px, otherwise that particular element is `display: none`. Likewise, the search box appears to have a static size/position whilst visible (although the green magnifying glass does alot of walking about at widths >1200px). So I don't think this will introduce any new issues.


Closes #84