### PR TITLE
Direct to all in one page for search

### DIFF
--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -181,6 +181,7 @@
         {{/more}}
       </ul>
     </div>
+    <!--
     <form class="d-flex col-md-2 search-form">
       <fieldset disabled>
       <input class="form-control me-2 searchbox" type="search" placeholder="{{ translate.Search }}" aria-label="{{ translate.Search }}">
@@ -189,6 +190,7 @@
         </button>
       </fieldset>
     </form>
+    -->
   </div><!--/div.container-fluid -->
 </nav>
 

--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -192,7 +192,7 @@
     </form>
     -->
    <li class="nav-item">
-       <a class="nav-link" href="{{#site}}{{root}}{{/site}}aio.html">Search</a>
+       <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}aio.html">Search</a>
    </li>
   </div><!--/div.container-fluid -->
 </nav>

--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -191,7 +191,7 @@
       </fieldset>
     </form>
     -->
-    <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}aio.html" role="button">Search in this lesson's "all in one" page</a>
+    <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}aio.html" role="button">{{ translate.SearchButton }}</a>
   </div><!--/div.container-fluid -->
 </nav>
 

--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -191,9 +191,7 @@
       </fieldset>
     </form>
     -->
-   <li class="nav-item">
-       <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}aio.html">Search</a>
-   </li>
+    <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}aio.html" role="button">Search</a>
   </div><!--/div.container-fluid -->
 </nav>
 

--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -191,7 +191,7 @@
       </fieldset>
     </form>
     -->
-    <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}aio.html" role="button">Search</a>
+    <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}aio.html" role="button">Search in this lesson's "all in one" page</a>
   </div><!--/div.container-fluid -->
 </nav>
 

--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -191,7 +191,9 @@
       </fieldset>
     </form>
     -->
+    {{^overview}}
     <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}aio.html" role="button">{{ translate.SearchButton }}</a>
+    {{/overview}}  
   </div><!--/div.container-fluid -->
 </nav>
 

--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -192,7 +192,7 @@
     </form>
     -->
    <li class="nav-item">
-       <a class="nav-link" href="{{#site}}{{root}}{{/site}}aio.html">{{ translate.AiO }}</a>
+       <a class="nav-link" href="{{#site}}{{root}}{{/site}}aio.html">Search</a>
    </li>
   </div><!--/div.container-fluid -->
 </nav>

--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -191,6 +191,9 @@
       </fieldset>
     </form>
     -->
+   <li class="nav-item">
+       <a class="nav-link" href="{{#site}}{{root}}{{/site}}aio.html">{{ translate.AiO }}</a>
+   </li>
   </div><!--/div.container-fluid -->
 </nav>
 


### PR DESCRIPTION
The goal of this PR (in combination with SANDPAPER PR LINK) is to:
- [x] Remove the inactive search box icon from lesson pages (this PR)
- [x] Replace with a button pointing towards the lesson's all in one page (this PR)
- [x] Make search button title translatable (https://github.com/ErinBecker/sandpaper/tree/translate-aio)
- [ ] Add a banner to the top of the all in one page directing folks to use ctl-f for search (SANDPAPER PR LINK) 

The screenshot below shows the replacement of the search box icon with a button pointing towards the lesson's all in one page: 
<img width="1243" alt="Screenshot 2024-03-22 at 3 13 34 PM" src="https://github.com/carpentries/varnish/assets/19176319/b7a727ff-59b3-47c2-b1b2-a8516d327dd7">

Note to self and @froggleston - if we end up merging this, please squash and merge, there's a lot of commits where I was experimenting.

Fixes https://github.com/carpentries/workbench/issues/8