### PR TITLE
Make "Search All in One" aware of learner/instructor distinction

### DIFF
--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -192,11 +192,11 @@
     </form>
     -->
     {{^overview}}
-    {{#learner}}
-    <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}learner/aio.html" role="button" aria-label="{{ translate.SearchButton }}">{{ translate.SearchButton }}</a>
-    {{/learner}}
     {{#instructor}}
     <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}instructor/aio.html" role="button" aria-label="{{ translate.SearchButton }}">{{ translate.SearchButton }}</a>
+    {{/instructor}}
+    {{^instructor}}
+    <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}learner/aio.html" role="button" aria-label="{{ translate.SearchButton }}">{{ translate.SearchButton }}</a>
     {{/instructor}}
     {{/overview}}
   </div><!--/div.container-fluid -->

--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -196,7 +196,7 @@
     <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}instructor/aio.html" role="button" aria-label="{{ translate.SearchButton }}">{{ translate.SearchButton }}</a>
     {{/instructor}}
     {{^instructor}}
-    <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}learner/aio.html" role="button" aria-label="{{ translate.SearchButton }}">{{ translate.SearchButton }}</a>
+    <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}aio.html" role="button" aria-label="{{ translate.SearchButton }}">{{ translate.SearchButton }}</a>
     {{/instructor}}
     {{/overview}}
   </div><!--/div.container-fluid -->

--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -192,7 +192,10 @@
     </form>
     -->
     {{^overview}}
+    {{^instructor}}
     <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}aio.html" role="button" aria-label="{{ translate.SearchButton }}">{{ translate.SearchButton }}</a>
+    {{/instructor}}
+    <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}instructor/aio.html" role="button" aria-label="{{ translate.SearchButton }}">{{ translate.SearchButton }}</a>
     {{/overview}}
   </div><!--/div.container-fluid -->
 </nav>

--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -192,10 +192,12 @@
     </form>
     -->
     {{^overview}}
-    {{^instructor}}
-    <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}aio.html" role="button" aria-label="{{ translate.SearchButton }}">{{ translate.SearchButton }}</a>
-    {{/instructor}}
+    {{#learner}}
+    <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}learner/aio.html" role="button" aria-label="{{ translate.SearchButton }}">{{ translate.SearchButton }}</a>
+    {{/learner}}
+    {{#instructor}}
     <a class="btn btn-primary" href="{{#site}}{{root}}{{/site}}instructor/aio.html" role="button" aria-label="{{ translate.SearchButton }}">{{ translate.SearchButton }}</a>
+    {{/instructor}}
     {{/overview}}
   </div><!--/div.container-fluid -->
 </nav>


### PR DESCRIPTION
Fixes https://github.com/carpentries/varnish/issues/135

Clicking the "Search the All in One page" from Instructor view brings up the Instructor AIO (with Instructor notes shown):

<img width="1380" alt="Screenshot 2024-05-21 at 9 34 24 AM" src="https://github.com/carpentries/varnish/assets/19176319/1a16fe59-ce65-420e-884d-39a825d20154">

While clicking "Search the All in One page" from the Learner view brings up the Learner version of the page (with no Instructor notes):

<img width="1377" alt="Screenshot 2024-05-21 at 9 34 33 AM" src="https://github.com/carpentries/varnish/assets/19176319/a86bccf9-3e28-4738-a4b1-7d55e4392ab5">

Thanks to @tobyhodges for noticing this and to @froggleston for help with the moustach syntax!
