### PR TITLE
Use favicon for specific carpentries

### DIFF
--- a/inst/pkgdown/templates/head.html
+++ b/inst/pkgdown/templates/head.html
@@ -22,11 +22,11 @@
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
     <!-- Responsive Favicon for The Carpentries -->
-    <link rel="apple-touch-icon" sizes="180x180" href="{{#site}}{{root}}{{/site}}apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="{{#site}}{{root}}{{/site}}favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="{{#site}}{{root}}{{/site}}favicon-16x16.png">
-    <link rel="manifest" href="{{#site}}{{root}}{{/site}}site.webmanifest">
-    <link rel="mask-icon" href="{{#site}}{{root}}{{/site}}safari-pinned-tab.svg" color="#5bbad5">
+    <link rel="apple-touch-icon" sizes="180x180" href="{{#site}}{{root}}{{/site}}favicons/{{#yaml}}{{carpentry}}{{/yaml}}/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{#site}}{{root}}{{/site}}favicons/{{#yaml}}{{carpentry}}{{/yaml}}/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{#site}}{{root}}{{/site}}favicons/{{#yaml}}{{carpentry}}{{/yaml}}/favicon-16x16.png">
+    <link rel="manifest" href="{{#site}}{{root}}{{/site}}favicons/{{#yaml}}{{carpentry}}{{/yaml}}/site.webmanifest">
+    <link rel="mask-icon" href="{{#site}}{{root}}{{/site}}favicons/{{#yaml}}{{carpentry}}{{/yaml}}/safari-pinned-tab.svg" color="#5bbad5">
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="white" />
     <meta name="theme-color" media="(prefers-color-scheme: dark)" content="black" />


### PR DESCRIPTION
Fix https://github.com/carpentries/varnish/issues/33.

Also fix point 1 in https://github.com/carpentries/sandpaper/issues/241 thanks to https://github.com/carpentries/sandpaper/pull/585.

Tested locally on https://github.com/swcarpentry/r-novice-inflammation and https://github.com/epiverse-trace/research-compendium.