### PR TITLE
Load Sass variables early and use mono_font variable

### DIFF
--- a/source/stylesheets/styles.css.scss
+++ b/source/stylesheets/styles.css.scss
@@ -1,6 +1,6 @@
 @import "bootstrap/scss/bootstrap.scss";
-@import "syntax-highlighting";
 @import "variables";
+@import "syntax-highlighting";
 @import "header";
 @import "callouts";
 @import "codeblocks";

--- a/source/stylesheets/syntax-highlighting.scss
+++ b/source/stylesheets/syntax-highlighting.scss
@@ -8,7 +8,7 @@ pre .img img, pre .r-plt img {
 }
 
 code {
-  font-family: 'Source Code Pro', monospace;
+  font-family: $mono_font, monospace;
   color: #000;
 }
 
@@ -21,7 +21,7 @@ p > code {
 /* Links ---------------------------------------------------- */
 
 code a:any-link {
-  font-family: 'Source Code Pro', monospace;
+  font-family: $mono_font, monospace;
   border-radius: 4px;
   text-decoration: underline;
   text-decoration-color: $gray-400;


### PR DESCRIPTION
Follow up from #151 

Without the first commit, `squash-sass.sh` complains because the `mono_font` variable has not yet been created when `syntax-highlighthing.scss` is turned into css.