### PR TITLE
Add copy-to-clipboard functionality to code blocks

### DIFF
--- a/source/javascripts/custom/copy-code.js
+++ b/source/javascripts/custom/copy-code.js
@@ -1,0 +1,7 @@
+$( document ).ready(function() {
+    $( ".copy-button" ).on( "click", async function( event ) {
+        const button = event.target;
+        const code = $( button ).siblings( "pre" ).children( "code" ).text();
+        await navigator.clipboard.writeText(code);
+    });
+});

--- a/source/javascripts/scripts.js
+++ b/source/javascripts/scripts.js
@@ -2,5 +2,6 @@
 #= require vendor/bootstrap/bootstrap
 #= require vendor/jquery-visible/jquery.visible
 #= require vendor/feather-icons/feather
+#= require custom/copy-code
 #= require custom/menu
 #= require custom/tabs

--- a/source/stylesheets/codeblocks.scss
+++ b/source/stylesheets/codeblocks.scss
@@ -80,12 +80,18 @@ pre.output > code::before {
 }
 // ZNK: end
 
-.code-label {
+.code-label, .copy-button {
   font-size: 18px;
   border-bottom: 1px solid $black;
   line-height: 23.4px;
   position: absolute;
-  right: 25px;
   margin-top:25px;
 }
 
+.code-label {
+  right: 25px;
+}
+
+.copy-button {
+  left: 25px;
+}


### PR DESCRIPTION
An accompanying patch for sandpaper adds buttons with class copy-button to code blocks.

The styling of the button is a suggestion.