### PR TITLE
Update life-cycle badge link to new docs

### DIFF
--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -23,7 +23,7 @@
         {{#pre_alpha}}
         <span class ="badge text-bg-danger">
           <abbr title="{{ translate.PreAlphaNote }}">
-            <a href="https://cdh.carpentries.org/the-lesson-life-cycle.html#early-development-pre-alpha-through-alpha" class="alert-link">
+            <a href="https://docs.carpentries.org/resources/curriculum/lesson-life-cycle.html" class="alert-link">
               <i aria-hidden="true" class="icon" data-feather="alert-octagon" style="border-radius: 5px"></i>
               {{ translate.iPreAlpha }}
             </a>
@@ -34,7 +34,7 @@
         {{#alpha}}
         <span class ="badge text-bg-warning">
           <abbr title="{{ translate.AlphaNote }}">
-            <a href="https://cdh.carpentries.org/the-lesson-life-cycle.html#field-testing-alpha-stage" class="alert-link">
+            <a href="https://docs.carpentries.org/resources/curriculum/lesson-life-cycle.html" class="alert-link">
               <i aria-hidden="true" class="icon" data-feather="alert-triangle" style="border-radius: 5px"></i>
               {{ translate.iAlpha }}
             </a>
@@ -45,7 +45,7 @@
         {{#beta}}
         <span class ="badge text-bg-info">
           <abbr title="{{ translate.BetaNote }}">
-            <a href="https://cdh.carpentries.org/the-lesson-life-cycle.html#polishing-beta-stage" class="alert-link">
+            <a href="https://docs.carpentries.org/resources/curriculum/lesson-life-cycle.html" class="alert-link">
               <i aria-hidden="true" class="icon" data-feather="alert-circle" style="border-radius: 5px"></i>
               {{ translate.iBeta }}
             </a>


### PR DESCRIPTION
I noticed the alpha/beta link from the header was pointing to the old docs.

New page doesn't appear to have anchors that can be linked, but it's short so I don't think that's an issue.



*I completed instructor training in February, I think this PR can be used as one of my checkout things🤷‍♂️, though I'd have made it regardless.*