### PR TITLE
Limit h3 and h4 sizes on wider monitors

### DIFF
--- a/source/stylesheets/styles.css.scss
+++ b/source/stylesheets/styles.css.scss
@@ -320,6 +320,14 @@ dt > * {
     font-size: 32px;
   }
 
+  h3 {
+    font-size: 26px;
+  }
+
+  h4 {
+    font-size: 22px;
+  }
+
 }
 
 @media print {


### PR DESCRIPTION
Fixes an issue where h3 and h4 elements would scale to larger sizes than h1 or h2 on larger monitors