### PR TITLE
Add config and template support for a language selection menu

### DIFF
--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -115,6 +115,18 @@
         </ul>
       </div>
       {{/language}}{{/yaml}}
+      {{#yaml}}{{#languages}}
+      <div class="dropdown">
+        <button class="btn btn-secondary dropdown-toggle " type="button" id="dropdownMenu2" data-bs-toggle="dropdown" aria-expanded="false">
+          <b>{{default}}</b>  <i data-feather="chevron-down"></i>
+        </button>
+        <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
+          {{#other}}
+          <li><button class="dropdown-item" type="button"><a href="{{ url }}">{{lang}}</a></button></li>
+          {{/other}}
+        </ul>
+      </div>
+      {{/languages}}{{/yaml}}
       <div class="dropdown" id="instructor-dropdown">
         {{#instructor}}
         <button class="btn btn-secondary dropdown-toggle bordered-button" type="button" id="dropdownMenu1" data-bs-toggle="dropdown" aria-expanded="false">


### PR DESCRIPTION
Hi everyone,

This is a small increment to allow having a navigation menu to select between multiple languages.
No assumption is made here on how each lesson in different languages is being built nor on which URL they live under.

To see this in action add the following to a lesson's `config.yaml`:

```yaml
languages:
  default: English
  other:
    - lang: "Español"
      url: https://swcarpentry.github.io/shell-novice-es/
    - lang: Deutsch
      url: https://swcarpentry.github.io/shell-novice-de/
    - lang: Italiano
      url: https://swcarpentry.github.io/shell-novice-it/
```

In this configuration `default` is the long-name of the default language, also specified by the `lang: en` setting.
`other` is an array of name-url pairs.

I decided not to touch the `{{#yaml}}{{#language}}` line (notice `language` in existing code vs `languages` introduced here) as I'm not aware of how the `language` tag is being used in the lesson template.
As far as I could tell, it isn't used but I took the cautious route here.

This PR with the above configuration renders to

<img width="475" height="239" alt="screenshot_2025-08-04_15-17-38_655055309" src="https://github.com/user-attachments/assets/123a2be0-296f-4458-8651-135ae4f781f5" />
